### PR TITLE
Move more common functions here

### DIFF
--- a/gtecs/common/config.py
+++ b/gtecs/common/config.py
@@ -1,0 +1,22 @@
+"""Package configuration functions."""
+
+import os
+from pathlib import Path
+
+
+def get_config_path():
+    """Get the location of the system config directory."""
+    # This is based on https://github.com/srstevenson/xdg
+    path = os.environ.get('XDG_CONFIG_HOME')
+    if path and os.path.isabs(path):
+        return Path(path)
+    return Path.home() / '.config'
+
+
+def get_package_config_path(package_name='gtecs'):
+    """Get the location of the config directory for the given package."""
+    base_path = get_config_path()
+    return base_path / package_name
+
+
+CONFIG_PATH = get_package_config_path()

--- a/gtecs/common/logging.py
+++ b/gtecs/common/logging.py
@@ -1,24 +1,21 @@
 """Standard format for creating log files."""
 
 import logging
-import os
 import sys
 import time
 from io import TextIOBase
 from logging import handlers
+from pathlib import Path
+
+from . import config
 
 
-def get_file_handler(name=None, logpath=None):
+def get_file_handler(name, out_path=None):
     """Get the file handler."""
-    if name is not None:
-        logfile = name + '.log'
-    else:
-        logfile = 'master.log'
-    if logpath is not None:
-        fname = os.path.join(logpath, logfile)
-    else:
-        fname = logfile
-    file_handler = handlers.WatchedFileHandler(fname, delay=True)
+    if out_path is None:
+        out_path = Path.cwd()
+    log_file = f'{name}.log'
+    log_path = out_path / log_file
 
     # formatter for stdout logging; does not include name of log
     formatter = logging.Formatter(
@@ -26,9 +23,11 @@ def get_file_handler(name=None, logpath=None):
         datefmt='%Y/%m/%d %H:%M:%S'
     )
     formatter.converter = time.gmtime
-    file_handler.setFormatter(formatter)
-    file_handler.setLevel(logging.DEBUG)
-    return file_handler
+
+    handler = handlers.WatchedFileHandler(log_path, delay=True)
+    handler.setFormatter(formatter)
+    handler.setLevel(logging.DEBUG)
+    return handler
 
 
 def get_stream_handler():
@@ -40,82 +39,10 @@ def get_stream_handler():
     )
     formatter.converter = time.gmtime
 
-    # add output to stdout
-    console = logging.StreamHandler(sys.stdout)
-    console.setFormatter(formatter)
-    console.setLevel(logging.INFO)
-    return console
-
-
-def get_logger(name=None, out_path=None, log_stdout=False, log_to_file=True, log_to_stdout=True):
-    """Provide standardised logging to all processes.
-
-    Each logger will write to stdout and a file name 'name.log'
-    in the directory given by `out_path`.
-
-    By default all levels from DEBUG up are written to the logfile,
-    and all levels from INFO up are written to stdout.
-
-    This function will not rename logfiles based on the date. The idea is
-    to use the UNIX utility logrotate to rotate the log files daily.
-
-    Parameters
-    ----------
-    name : str
-        the name of the logger, which is also used for the name of the logfile
-        if no name is given logs will be saved to `master.log`
-    out_path : str
-        where to save log files (default is the current directory)
-    log_stdout : bool
-        whether to log all stdout, not just log commands
-    log_to_file : bool
-        whether to log to file or not
-    log_to_stdout : bool
-        whether to log to stdout or not
-
-    Returns
-    --------
-    log : `logging.Logger`
-        a Logger class to use for Logging.
-
-    Example
-    --------
-    The function can be used as follows::
-
-        log = get_logger('pilot')
-        if pilot.running:
-            log.info('Pilot started successfully')
-        else:
-            log.error('Pilot not started!')
-        # log exceptions to file and stdout
-        try:
-            print "Hi There"  # breaks in python 3
-        except Exception:
-            log.exception('')
-
-    """
-    log = logging.getLogger(name)
-    log.setLevel(logging.DEBUG)
-
-    # if the handlers are not empty this has been called
-    # before and we shouldn't add more handlers
-    if log.handlers != []:
-        return log
-
-    # add a stdout handler
-    if log_to_stdout:
-        log.addHandler(get_stream_handler())
-
-    # add a file handler
-    if log_to_file:
-        log.addHandler(get_file_handler(name, out_path))
-
-    # redirect system stdout
-    if log_stdout:
-        sys.stdout = StreamToLogger(log, logging.INFO)
-        sys.stderr = StreamToLogger(log, logging.ERROR)
-
-    return log
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+    handler.setLevel(logging.INFO)
+    return handler
 
 
 class StreamToLogger(TextIOBase):
@@ -136,38 +63,63 @@ class StreamToLogger(TextIOBase):
         pass
 
 
-def set_logger_output(logger, out_path=None, log_to_file=True, log_to_stdout=True):
-    """Add or remove handlers to a logger to print to file or stdout.
+def get_log_path():
+    """Get the default directory where log files are stored."""
+    return config.CONFIG_PATH / 'logs'
+
+
+def get_logger(name, out_path=None, capture_stdout=True, suppress_stdout=False):
+    """Provide standardised logging to all processes.
+
+    Each logger will write to stdout and a file name '<name>.log'
+    in the directory given by `out_path`.
+
+    By default all levels from DEBUG up are written to the logfile,
+    and all levels from INFO up are written to stdout.
+
+    This function will not rename logfiles based on the date. The idea is
+    to use the UNIX utility logrotate to rotate the log files daily.
 
     Parameters
     ----------
-    logger : `logging.Logger`
-        the logger to add or remove handlers from
-    log_to_file : bool
-        ensure logger logs to file
-    log_to_stdout : bool
-        ensure logger logs to stdout
+    name : str
+        the name of the logger, which is also used for the name of the logfile
+
+    out_path : str or None
+        path to save log entries to
+        if None, default to the module config directory (`config.CONFIG_PATH`/logs/)
+    capture_stdout : bool, default=True
+        if True, log all stdout not just log commands
+    suppress_stdout : bool, default=False
+        if True, do not repeat log commands to stdout
 
     """
-    file_logger_truefalse = [isinstance(hl, logging.handlers.WatchedFileHandler)
-                             for hl in logger.handlers]
-    already_has_file_logger = any(file_logger_truefalse)
-    stdout_logger_truefalse = [isinstance(hl, logging.StreamHandler)
-                               for hl in logger.handlers]
-    already_has_stdout_logger = any(stdout_logger_truefalse)
+    log = logging.getLogger(name)
 
-    if log_to_file:
-        if not already_has_file_logger:
-            logger.addHandler(get_file_handler(logger.name, out_path))
-    else:
-        if already_has_file_logger:
-            handler = logger.handlers[file_logger_truefalse.index(True)]
-            logger.removeHandler(handler)
+    # If the handlers are not empty this has been called before,
+    # and we shouldn't add more handlers
+    if log.handlers != []:
+        return log
 
-    if log_to_stdout:
-        if not already_has_stdout_logger:
-            logger.addHandler(get_stream_handler())
-    else:
-        if already_has_stdout_logger:
-            handler = logger.handlers[stdout_logger_truefalse.index(True)]
-            logger.removeHandler(handler)
+    # Set the overall log level (also set by the handlers)
+    log.setLevel(logging.DEBUG)
+
+    # Add a handler to log to the specified file (<name>.log)
+    if out_path is None:
+        out_path = get_log_path()
+    if not isinstance(out_path, Path):
+        out_path = Path(out_path)
+    if not out_path.exists():
+        out_path.mkdir(parents=True, exist_ok=True)
+    log.addHandler(get_file_handler(name, out_path))
+
+    # Add a handler to log to stdout
+    if not suppress_stdout:
+        log.addHandler(get_stream_handler())
+
+    # Redirect system stdout to the log
+    if capture_stdout:
+        sys.stdout = StreamToLogger(log, logging.INFO)
+        sys.stderr = StreamToLogger(log, logging.ERROR)
+
+    return log

--- a/gtecs/common/logging.py
+++ b/gtecs/common/logging.py
@@ -17,10 +17,10 @@ def get_file_handler(name, out_path=None):
     log_file = f'{name}.log'
     log_path = out_path / log_file
 
-    # formatter for stdout logging; does not include name of log
+    # formatter for file logging; does not include name of log (since it's the file name)
     formatter = logging.Formatter(
-        '%(asctime)s:%(levelname)s - %(message)s',
-        datefmt='%Y/%m/%d %H:%M:%S'
+        '%(asctime)s.%(msecs)03d:%(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
     )
     formatter.converter = time.gmtime
 
@@ -35,7 +35,7 @@ def get_stream_handler():
     # formatter for stdout logging; includes name of log
     formatter = logging.Formatter(
         '%(asctime)s.%(msecs)03d:%(name)s:%(levelname)s - %(message)s',
-        datefmt='%Y/%m/%d %H:%M:%S'
+        datefmt='%Y-%m-%d %H:%M:%S'
     )
     formatter.converter = time.gmtime
 

--- a/gtecs/common/package.py
+++ b/gtecs/common/package.py
@@ -1,15 +1,10 @@
 """Package management functions."""
 
+import importlib.resources as pkg_resources
 import os
+from importlib.metadata import version
 
 import configobj
-
-from importlib.metadata import version
-try:
-    import importlib.resources as pkg_resources
-except ImportError:
-    # Python < 3.7
-    import importlib_resources as pkg_resources  # type: ignore
 
 import validate
 

--- a/gtecs/common/system.py
+++ b/gtecs/common/system.py
@@ -1,0 +1,195 @@
+"""Functions for dealing with system processes."""
+
+import abc
+import signal
+import socket
+import subprocess
+import sys
+from contextlib import contextmanager
+
+import pid
+
+from . import config
+
+
+def get_local_ip():
+    """Get local IP address.
+
+    https://stackoverflow.com/a/28950776
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(0)
+    try:
+        # doesn't even have to be reachable
+        s.connect(('10.255.255.255', 1))
+        ip_addr = s.getsockname()[0]
+    except Exception:
+        ip_addr = '127.0.0.1'
+    finally:
+        s.close()
+    return ip_addr
+
+
+def execute_command(command_string, timeout=30):
+    """Execute a command that should return quickly."""
+    print('{}:'.format(command_string))
+    try:
+        p = subprocess.Popen(command_string,
+                             shell=True,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
+        ret_str, _ = p.communicate(timeout=timeout)
+        print('> ' + ret_str.strip().decode().replace('\n', '\n> '))
+        return 0
+    except subprocess.TimeoutExpired:
+        print('Command {} timed out after {}s'.format(command_string, timeout))
+        return 1
+
+
+def execute_long_command(command_string):
+    """Execute a command that might not return immediately.
+
+    For example the tail command for logs (because you can use tail's -f param),
+    or obs_scripts.
+
+    """
+    print(command_string)
+    p = subprocess.Popen(command_string, shell=True, close_fds=True)
+    try:
+        p.wait()
+    except KeyboardInterrupt:
+        print('...ctrl+c detected - closing ({})...'.format(command_string))
+        try:
+            p.terminate()
+        except OSError:
+            pass
+        p.wait()
+
+
+def kill_process(pid_name, host='127.0.0.1', verbose=False):
+    """Kill any specified processes."""
+    pid = get_pid(pid_name, host)
+
+    command_string = 'kill -9 {}'.format(pid)
+    if host not in ['127.0.0.1', get_local_ip()]:
+        command_string = "ssh {} '{}'".format(host, command_string)
+
+    if verbose:
+        print(command_string)
+    output = subprocess.getoutput(command_string)
+    if 'No route to host' in output:
+        raise ConnectionError('Cannot connect to host {}'.format(host))
+
+    clear_pid(pid_name, host)
+
+    print('Killed process {} on {}'.format(pid, host))
+
+
+class MultipleProcessError(Exception):
+    """To be used if multiple instances of a process are detected."""
+
+    pass
+
+
+def get_pid_path():
+    """Get the default directory where PID files are stored."""
+    return config.CONFIG_PATH / 'pid'
+
+
+@contextmanager
+def make_pid_file(pid_name):
+    """Create a PID file."""
+    try:
+        pid_path = get_pid_path()
+        with pid.PidFile(pid_name, pid_path):
+            yield
+    except pid.PidFileError:
+        # there can only be one
+        raise MultipleProcessError('Process "{}" already running'.format(pid_name))
+
+
+def get_pid(pid_name, host='127.0.0.1', verbose=False):
+    """Check if a pid file exists with the given name.
+
+    Returns the pid if it is found, or None if not.
+    """
+    # pid.PidFile(pid_name, pid_path).check() is nicer,
+    # but won't work with remote machines
+    pid_file = pid_name + '.pid'
+    pid_path = get_pid_path() / pid_file
+
+    command_string = 'cat {}'.format(pid_path)
+    if host not in ['127.0.0.1', get_local_ip()]:
+        # NOTE this assumes the pid path is the same on the remote machine,
+        # which should be now we've standardised on the ~/.config directory.
+        # Unless they changed XDG_CONFIG_HOME for some reason...
+        command_string = "ssh {} '{}'".format(host, command_string)
+
+    if verbose:
+        print(command_string)
+    output = subprocess.getoutput(command_string)
+    if 'No route to host' in output:
+        raise ConnectionError('Cannot connect to host {}'.format(host))
+
+    if 'No such file or directory' in output:
+        return None
+    else:
+        return int(output)
+
+
+def clear_pid(pid_name, host='127.0.0.1', verbose=False):
+    """Clear a pid in case we've killed the process."""
+    pid_file = pid_name + '.pid'
+    pid_path = get_pid_path() / pid_file
+
+    command_string = 'rm {}'.format(pid_path)
+    if host not in ['127.0.0.1', get_local_ip()]:
+        # NOTE: This assumes the pid path is the same on the remote machine,
+        # which should be now we've standardised on the ~/.config directory.
+        # Unless they changed XDG_CONFIG_HOME for some reason...
+        command_string = "ssh {} '{}'".format(host, command_string)
+
+    if verbose:
+        print(command_string)
+    output = subprocess.getoutput(command_string)
+    if 'No route to host' in output:
+        raise ConnectionError('Cannot connect to host {}'.format(host))
+
+    if not output or 'No such file or directory' in output:
+        return 0
+    else:
+        print(output)
+        return 1
+
+
+class NeatCloser(metaclass=abc.ABCMeta):
+    """Neatly handles closing down of processes.
+
+    This is an abstract class.
+
+    Implement the tidy_up method to set the commands which
+    get run after receiving an instruction to stop
+    before the task shuts down.
+
+    Once you have a concrete class based on this abstract class,
+    simply create an instance of it and the tidy_up function will
+    be caused on SIGINT and SIGTERM signals before closing.
+    """
+
+    def __init__(self, task_name):
+        self.task_name = task_name
+        # redirect SIGTERM, SIGINT to us
+        signal.signal(signal.SIGTERM, self.interrupt)
+        signal.signal(signal.SIGINT, self.interrupt)
+
+    def interrupt(self, sig, handler):
+        """Catch interrupts."""
+        print('{} received kill signal'.format(self.task_name))
+        # do things here on interrupt
+        self.tidy_up()
+        sys.exit(1)
+
+    @abc.abstractmethod
+    def tidy_up(self):
+        """Must be implemented to define tasks to run when closed before process is over."""
+        return

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 """Setup script for the gtecs-common package."""
-from setuptools import setup, find_namespace_packages
+from setuptools import find_namespace_packages, setup
 
 
 REQUIRES = ['requests',
             'configobj',
+            'pid',
             ]
 
 setup(name='gtecs-common',


### PR DESCRIPTION
This PR moves more functions from the original G-TeCS package (now `gtecs-control`) to this newer common package:
 * Config files are now stored in a systematic way across all packages, following the convention that I described in https://github.com/GOTO-OBS/gtecs-control/issues/433 this is now by default in `~/.config/gtecs/`. This is where the logs and other files will live from now on, excepting output files like camera images.
   * This does not include any changes to the current monolithic package-level config files, that could use another issue.
 * At the same time, I've updated the log formatting so that both file and STDOUT lines follow the format `YYYY-MM-DD HH:MM:SS.SSS`. Previously they would use slashes instead of dashes (a clear violation of ISO 8601), and for some reason milliseconds was only printed to stdout not saved in the files. These changes should make the logs much easier to parse in the future.
    * This does not include anything about log rotation, that could use another issue.
 * Multiple functions to do with system processes and PID files have moved from `gtecs.control.misc` to the new `gtecs.common.system` module. This in particular finally means that `gtecs-obs` and `gtecs-alert` are no longer dependent on `control`, which I'd say marks the final endpoint of "The Big Split" (https://github.com/GOTO-OBS/gtecs-control/issues/496).
    * This does not include moving the core daemon functions here or remaking the hardware daemons into system processes, that could use another issue.

You get the idea, no huge changes just a quick tidy up between major projects.