### PR TITLE
Add option for remote config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *.egg-info/
+*build/
 
 # Visual Studio Code files
 *.browse*

--- a/gtecs/common/package.py
+++ b/gtecs/common/package.py
@@ -4,55 +4,85 @@ import importlib.resources as pkg_resources
 import os
 from importlib.metadata import version
 
-import configobj
+from configobj import ConfigObj
+
+from fabric.connection import Connection
 
 import validate
 
 
-def load_config(package, config_file):
+def load_config(package, config_file, remote_host=None, remote_user=None):
     """Load and validate package configuration file.
 
     Parameters
     ----------
     package : str
         The gtecs subpackage name (e.g. 'control', 'obs', 'alert')
-
     config_file : str, or list of str
-        The name for the package config file (e.g. '`.gtecs.conf')
+        The name for the package config file (e.g. '.gtecs.conf')
+
+    remote_host : str or None, default=None
+        If given, load the config file from the given remote host
+        This uses fabric to connect through SSH, and assumes that no password is needed.
+        Note the remote config file will still be validated based on the local configspec
+        for the given gtecs package.
+    remote_user : str or None, default=None
+        The username to use when connecting to `remote_host`.
+        If None then the same username as the client is assumed.
 
     """
-    # Load package configspec file
-    spec = pkg_resources.read_text(f'gtecs.{package}.data', 'configspec.ini').split('\n')
-
-    # Create empty spec for default parameters
-    config = configobj.ConfigObj({}, configspec=spec)
-
-    # Try to find the config file, look in the home directory and
-    # anywhere specified by GTECS_CONF environment variable
     if isinstance(config_file, str):
         filenames = [config_file]
     else:
         filenames = config_file
-    home = os.path.expanduser('~')
-    paths = [home, os.path.join(home, 'gtecs'), os.path.join(home, '.gtecs')]
-    if 'GTECS_CONF' in os.environ:
-        paths.append(os.environ['GTECS_CONF'])
-    config_file = None
-    config_path = None
+
+    # Options for the location of the config file:
+    # - Home directory (~)
+    # - ~/gtecs or ~/.gtecs
+    # - Any other path given by the 'GTECS_CONF' environment variable
+    if remote_host is None:
+        home = os.path.expanduser('~')
+        paths = [home, os.path.join(home, 'gtecs'), os.path.join(home, '.gtecs')]
+        if 'GTECS_CONF' in os.environ:
+            paths.append(os.environ['GTECS_CONF'])
+    else:
+        # The SFTP connection will automatically start in the home directory
+        paths = ['', 'gtecs', '.gtecs']
+        # We will need to check the remote environment
+        # TODO: I'm not sure this works? Depends how the variable is set.
+        with Connection(remote_host, user=remote_user) as c:
+            result = c.run('echo $GTECS_CONF', hide='both').stdout.strip()
+            if result != '':
+                paths.append(result)
+
+    # Load package configspec file
+    spec = pkg_resources.read_text(f'gtecs.{package}.data', 'configspec.ini').split('\n')
+
+    # Create empty spec for default parameters, in case we don't find any file
+    config = ConfigObj({}, configspec=spec)
+
+    # Search all possible paths for the config file
+    config_filepath = None
     for path in paths:
         for file in filenames:
-            try:
-                with open(os.path.join(path, file)) as source:
-                    config = configobj.ConfigObj(source, configspec=spec)
-                    config_file = file
-                    config_path = path
-                    break
-            except IOError:
-                pass
-    if config_file is not None and config_path is not None:
-        loc = os.path.join(config_path, config_file)
-    else:
-        loc = None
+            filepath = os.path.join(path, file)
+            if remote_host is None:
+                try:
+                    with open(filepath) as source:
+                        config = ConfigObj(source, configspec=spec)
+                        config_filepath = filepath
+                        break
+                except IOError:
+                    pass
+            else:
+                try:
+                    with Connection(remote_host, user=remote_user) as c, c.sftp() as sftp:
+                        with sftp.open(filepath) as source:
+                            config = ConfigObj(source, configspec=spec)
+                            config_filepath = filepath
+                            break
+                except FileNotFoundError:
+                    pass
 
     # Validate ConfigObj, filling defaults from configspec if missing from config file
     validator = validate.Validator()
@@ -62,7 +92,7 @@ def load_config(package, config_file):
         print([k for k in result if not result[k]])
         raise ValueError(f'{config_file} config file validation failed')
 
-    return config, spec, loc
+    return config, spec, config_filepath
 
 
 def get_package_version(package):

--- a/gtecs/common/system.py
+++ b/gtecs/common/system.py
@@ -72,7 +72,7 @@ def kill_process(pid_name, host='127.0.0.1', verbose=False):
 
     command_string = 'kill -9 {}'.format(pid)
     if host not in ['127.0.0.1', get_local_ip()]:
-        command_string = "ssh {} '{}'".format(host, command_string)
+        command_string = "ssh {} '{}'".format(host, command_string)  # TODO: use fabric?
 
     if verbose:
         print(command_string)
@@ -123,7 +123,7 @@ def get_pid(pid_name, host='127.0.0.1', verbose=False):
         # NOTE this assumes the pid path is the same on the remote machine,
         # which should be now we've standardised on the ~/.config directory.
         # Unless they changed XDG_CONFIG_HOME for some reason...
-        command_string = "ssh {} '{}'".format(host, command_string)
+        command_string = "ssh {} '{}'".format(host, command_string)  # TODO: use fabric?
 
     if verbose:
         print(command_string)
@@ -147,7 +147,7 @@ def clear_pid(pid_name, host='127.0.0.1', verbose=False):
         # NOTE: This assumes the pid path is the same on the remote machine,
         # which should be now we've standardised on the ~/.config directory.
         # Unless they changed XDG_CONFIG_HOME for some reason...
-        command_string = "ssh {} '{}'".format(host, command_string)
+        command_string = "ssh {} '{}'".format(host, command_string)  # TODO: use fabric?
 
     if verbose:
         print(command_string)

--- a/gtecs/common/system.py
+++ b/gtecs/common/system.py
@@ -21,7 +21,7 @@ def get_local_ip():
     s.settimeout(0)
     try:
         # doesn't even have to be reachable
-        s.connect(('10.255.255.255', 1))
+        s.connect(('10.55.55.55', 1))  # 10.255.255.255 sometimes gave permission denied errors?
         ip_addr = s.getsockname()[0]
     except Exception:
         ip_addr = '127.0.0.1'

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import find_namespace_packages, setup
 
 REQUIRES = ['requests',
             'configobj',
+            'fabric',
             'pid',
             ]
 


### PR DESCRIPTION
As above, this PR adds in the ability to load remote config files. This will be particularly useful for splitting up the control interfaces (see https://github.com/GOTO-OBS/gtecs-control/issues/606).