### PR TITLE
Update Slack posting

### DIFF
--- a/gtecs/common/slack.py
+++ b/gtecs/common/slack.py
@@ -89,7 +89,11 @@ def send_message(text, channel, token,
             message_ts = response['ts']
         else:
             # We want to get the timestamp of the message, not the file
-            message_ts = response['file']['shares']['private'][channel][0]['ts']
+            # It could be a public or private channel
+            try:
+                message_ts = response['file']['shares']['public'][channel][0]['ts']
+            except KeyError:
+                message_ts = response['file']['shares']['private'][channel][0]['ts']
 
         try:
             # Get permalink for the message identified by the timestamp

--- a/gtecs/common/slack.py
+++ b/gtecs/common/slack.py
@@ -1,12 +1,13 @@
 """Slack messaging functions."""
 
-import os
 import json
+import os
 
 import requests
 
 
-def send_message(text, channel, token, attachments=None, blocks=None, filepath=None):
+def send_message(text, channel, token,
+                 attachments=None, blocks=None, filepath=None, return_link=False):
     """Send a message to Slack.
 
     Parameters
@@ -32,6 +33,8 @@ def send_message(text, channel, token, attachments=None, blocks=None, filepath=N
         A local path to a file to be added to the message.
         NB a message can have a file OR attachments/blocks, not both.
 
+    return_link : bool, optional (default=False)
+        If True, return a permalink URL to the posted message.
 
     """
     if (attachments is not None or blocks is not None) and filepath is not None:
@@ -53,7 +56,7 @@ def send_message(text, channel, token, attachments=None, blocks=None, filepath=N
                        'attachments': json.dumps(attachments) if attachments else None,
                        'blocks': json.dumps(blocks) if blocks else None,
                        }
-            responce = requests.post(url, payload).json()
+            response = requests.post(url, payload).json()
         else:
             url = 'https://slack.com/api/files.upload'
             filename = os.path.basename(filepath)
@@ -66,15 +69,44 @@ def send_message(text, channel, token, attachments=None, blocks=None, filepath=N
                        'initial_comment': text,
                        }
             with open(filepath, 'rb') as file:
-                responce = requests.post(url, payload, files={'file': file}).json()
-        if not responce.get('ok'):
-            if 'error' in responce:
-                raise Exception('Unable to send message: {}'.format(responce['error']))
+                response = requests.post(url, payload, files={'file': file}).json()
+
+        if not response.get('ok'):
+            if 'error' in response:
+                raise Exception('Unable to send message: {}'.format(response['error']))
             else:
                 raise Exception('Unable to send message')
+
     except Exception as err:
         print('Connection to Slack failed! - {}'.format(err))
         print('Message:', text)
         print('Attachments:', attachments)
         print('Blocks:', blocks)
         print('Filepath:', filepath)
+
+    if return_link:
+        if not filepath:
+            message_ts = response['ts']
+        else:
+            # We want to get the timestamp of the message, not the file
+            message_ts = response['file']['shares']['private'][channel][0]['ts']
+
+        try:
+            # Get permalink for the message identified by the timestamp
+            url = 'https://slack.com/api/chat.getPermalink'
+            payload = {'token': token,
+                       'channel': channel,
+                       'message_ts': message_ts,
+                       }
+            response = requests.post(url, payload).json()
+
+            if not response.get('ok'):
+                if 'error' in response:
+                    raise Exception('Unable to retrieve permalink: {}'.format(response['error']))
+
+            return response['permalink']
+
+        except Exception as err:
+            print('Unable to retrieve permalink - {}'.format(err))
+    else:
+        return response

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ REQUIRES = ['requests',
             'fabric',
             'pid',
             'pymysql',
-            'psycopg2',
+            # 'psycopg2',  # remove as requirement as it requires postgresql to be installed
             'sqlalchemy>=2',
             ]
 


### PR DESCRIPTION
This is a small update to the Slack API code that allows custom usernames and emoji icons when posting text (not images frustratingly, see the comment for details) and returns a permalink to the posted message to future messages to reference it (used by the sentinel when forwarding alert messages from other channels).