### PR TITLE
Add warnings for config params that are not in the spec

### DIFF
--- a/gtecs/common/package.py
+++ b/gtecs/common/package.py
@@ -56,12 +56,12 @@ def load_config(package, config_file, remote_host=None, remote_user=None):
                 paths.append(result)
 
     # Load package configspec file
-    spec = pkg_resources.read_text(f'gtecs.{package}.data', 'configspec.ini').split('\n')
-
-    # Create empty spec for default parameters, in case we don't find any file
-    config = ConfigObj({}, configspec=spec)
+    package_files = pkg_resources.files(f'gtecs.{package}.data')
+    with open(package_files.joinpath('configspec.ini')) as spec_file:
+        spec = ConfigObj(spec_file, _inspec=True)
 
     # Search all possible paths for the config file
+    config = None
     config_filepath = None
     for path in paths:
         for file in filenames:
@@ -84,6 +84,10 @@ def load_config(package, config_file, remote_host=None, remote_user=None):
                 except FileNotFoundError:
                     pass
 
+    # We didn't find a file, so just create an empty config to get default parameters
+    if config is None:
+        config = ConfigObj({}, configspec=spec)
+
     # Validate ConfigObj, filling defaults from configspec if missing from config file
     validator = validate.Validator()
     result = config.validate(validator)
@@ -91,6 +95,12 @@ def load_config(package, config_file, remote_host=None, remote_user=None):
         print('Config file validation failed')
         print([k for k in result if not result[k]])
         raise ValueError(f'{config_file} config file validation failed')
+
+    # Also report any keys in the config that are not in the spec
+    # This is useful for catching typos or any deprecated parameters
+    for key in config.keys():
+        if key not in spec:
+            print(f'Warning: {key} in {config_filepath.split("/")[-1]} is not in the configspec')
 
     return config, spec, config_filepath
 

--- a/gtecs/common/package.py
+++ b/gtecs/common/package.py
@@ -56,8 +56,7 @@ def load_config(package, config_file, remote_host=None, remote_user=None):
                 paths.append(result)
 
     # Load package configspec file
-    package_files = pkg_resources.files(f'gtecs.{package}.data')
-    with open(package_files.joinpath('configspec.ini')) as spec_file:
+    with pkg_resources.open_text(f'gtecs.{package}.data', 'configspec.ini') as spec_file:
         spec = ConfigObj(spec_file, _inspec=True)
 
     # Search all possible paths for the config file

--- a/gtecs/common/slack.py
+++ b/gtecs/common/slack.py
@@ -117,6 +117,7 @@ def send_message(text, channel, token,
         print('Attachments:', attachments)
         print('Blocks:', blocks)
         print('Filepath:', filepath)
+        return
 
     if return_link:
         if not filepath:


### PR DESCRIPTION
There are a few advantages to this: it should avoid any typos and give some warning if a parameter is renamed or removed.

This PR also includes a bug fix that should have been included in #7.