### PR TITLE
Update Slack code and file upload

### DIFF
--- a/gtecs/common/slack.py
+++ b/gtecs/common/slack.py
@@ -77,6 +77,11 @@ def send_message(text, channel, token,
             if 'mrkdwn_in' not in attachment:
                 attachment['mrkdwn_in'] = ['text']
 
+    # If blocks are included you can't give text, you have to add it as the first block.
+    if blocks and text:
+        blocks.insert(0, {'type': 'section', 'text': {'type': 'mrkdwn', 'text': text}})
+        text = None
+
     try:
         if not filepath:
             url = 'https://slack.com/api/chat.postMessage'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_namespace_packages, setup
 
 
-REQUIRES = ['requests',
+REQUIRES = ['slack_sdk>=3.20.1',
             'configobj',
             'fabric',
             'pid',


### PR DESCRIPTION
See #9, this PR updates our code to use the official Python SDK which makes dealing with the file upload changes a lot easier.

Unfortunately, one of the other consequences of Slack's changes is that it takes a few seconds for the file to be shared with the channel, so if the link has been requested we have to wait after uploading (see https://github.com/slackapi/python-slack-sdk/issues/1329). The sentinel uses this to link alerts between channels, so this will introduce a small delay. We should probably send the notice in parallel, that's another issue for that repo.

Closes #9 